### PR TITLE
Bash Improvements Mostly

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches: 
       - main
+  workflow_dispatch:
 
 jobs:
   build_and_test:

--- a/.github/workflows/data_pipeline.yaml
+++ b/.github/workflows/data_pipeline.yaml
@@ -3,6 +3,7 @@ name: Data Pipeline
 on:
   schedule:
     - cron: "0 9 * * *"
+  workflow_dispatch:
 
 jobs:
   data_pipeline:
@@ -29,7 +30,7 @@ jobs:
         run: sudo ./build/install_packages.sh openvpn
 
       - name: Connect to ProtonVPN
-        run: sudo ./vpn/connect.sh ./vpn/config.ovpn
+        run: ./vpn/connect.sh vpn/config.ovpn
         env:
             VPN_USERNAME: ${{  secrets.PROTONVPN_USERNAME }}
             VPN_PASSWORD: ${{  secrets.PROTONVPN_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,36 @@
-# matteosox/nba
+<h1 align="center">matteosox/nba</h1>
+
+## [Badges? We ain't got no badges! We don't need no badges! I don't have to show you any stinking badges!](https://www.youtube.com/watch?v=VqomZQMZQCQ)
+
+<h3 align="center">
+Status<br>
+<a href="https://github.com/matteosox/nba/actions/workflows/data_pipeline.yaml"><img alt="Data Pipeline" src="https://github.com/matteosox/nba/actions/workflows/data_pipeline.yaml/badge.svg"></a>
+<a href="https://github.com/matteosox/nba/actions/workflows/build_test.yaml"><img alt="Build and Test" src="https://github.com/matteosox/nba/actions/workflows/build_test.yaml/badge.svg"></a>
+<a href="https://nba.mattefay.com"><img alt="Website Status" src="https://img.shields.io/website?down_color=red&down_message=offline&label=nba.mattefay.com&up_color=brightgreen&up_message=online&url=https%3A%2F%2Fnba.mattefay.com"></a>
+<br>Languages<br>
+<a href="https://docs.python.org/3.8/"><img alt="Python: 3.8" src="https://img.shields.io/static/v1?label=Python&message=3%2C8&logo=python&color=%233776AB"></a>
+<a href="https://www.gnu.org/software/bash/"><img alt="Bash: 5.1" src="https://img.shields.io/static/v1?label=Bash&message=5%2C1&logo=GNU-bash&color=%234EAA25"></a>
+<a href="https://www.typescriptlang.org/"><img alt="Typescript: " src="https://img.shields.io/github/package-json/dependency-version/matteosox/nba/dev/typescript?filename=app%2Fpackage.json&logo=typescript&color=%233178C6&label=Typescript"></a>
+<br>Services<br>
+<a href="https://github.com/matteosox/nba"><img alt="VCS: Github" src="https://img.shields.io/static/v1?label=VCS&message=Github&logo=github&color=%23181717"></a>
+<a href="https://github.com/matteosox/nba/actions"><img alt="CI: Github Actions" src="https://img.shields.io/static/v1?label=CI&message=Github%20Actions&logo=Github-Actions&color=%232088FF"></a>
+<a href="https://hub.docker.com/repository/docker/matteosox/nba"><img alt="Container Repo: Docker Hub" src="https://img.shields.io/static/v1?label=Container%20Repo&message=Docker%20Hub&logo=Docker&color=%232496ED"></a>
+<a href="https://protonvpn.com/"><img alt="VPN: ProtonVPN" src="https://img.shields.io/static/v1?label=VPN&message=ProtonVPN&logo=ProtonVPN&color=%2356B366"></a>
+<a href="https://aws.amazon.com/s3/"><img alt="Storage: AWS S3" src="https://img.shields.io/static/v1?label=Storage&message=AWS%20S3&logo=Amazon-S3&color=%23569A31"></a>
+<a href="https://vercel.com/matteosox/nba"><img alt="CD & Hosting: Vercel" src="https://img.shields.io/static/v1?label=CD%20%26%20Hosting&message=Vercel&logo=Vercel&color=%23000000"></a>
+<a href="https://www.hover.com/"><img alt="Domain: Hover" src="https://img.shields.io/static/v1?label=Domain&message=Hover"></a>
+<br>Dependencies<br>
+<a href="https://jupyter.org/try"><img alt="Analysis environment: Jupyter" src="https://img.shields.io/static/v1?label=Analysis%20environment&message=Jupyter&logo=Jupyter&color=%23F37626"></a>
+<a href="https://www.dynaconf.com/"><img alt="Config: Dynaconf" src="https://img.shields.io/static/v1?label=Config&message=Dynaconf"></a>
+<a href="https://nextjs.org/"><img alt="Web framework: Next.js" src="https://img.shields.io/static/v1?label=Web%20framework&message=Next%2Cjs&logo=Next.js&color=%23000000"></a>
+<a href="https://reactjs.org/"><img alt="UI: React" src="https://img.shields.io/static/v1?label=UI&message=React&logo=React&color=%2361DAFB"></a>
+<a href="https://pbpstats.readthedocs.io/en/latest/"><img alt="NBA stats: pbpstats" src="https://img.shields.io/static/v1?label=NBA%20stats&message=pbpstats"></a>
+<a href="https://docs.pymc.io/"><img alt="Models: pymc3" src="https://img.shields.io/static/v1?label=Models&message=pymc3"></a>
+<br>Testing<br>
+<a href="https://github.com/psf/black"><img alt="Python style: Black" src="https://img.shields.io/static/v1?label=Python%20style&message=Black&color=%23000000"></a>
+<a href="https://www.pylint.org/"><img alt="Python quality: Pylint" src="https://img.shields.io/static/v1?label=Python%20quality&message=Pylint"></a>
+<a href="https://www.shellcheck.net/"><img alt="Bash quality: ShellCheck" src="https://img.shields.io/static/v1?label=Bash%20quality&message=ShellCheck"></a>
+</p>
 
 ## Info
 
@@ -131,6 +163,10 @@ The package is installed using `setuptools`'s [`find_packages` function](https:/
 
 Thus, to run tests, we mount the root of the repo to the location in the container it's been installed. All of this is handled nicely by running `test.sh`, which uses the `notebook` container.
 
+#### Bash Script Tests
+
+We use [ShellCheck](https://github.com/koalaman/shellcheck) to test all the bash scripts in the repo. This helps us avoid some of the many sharp corners of bash, improving quality, readability, and style. This is run in `./test/shellcheck.sh`.
+
 #### Web App Tests
 
 **TBD**
@@ -142,6 +178,10 @@ _TL;DR: To push docker images to Docker Hub, run `./cicd/push.sh`._
 ## Data Pipeline
 
 We run a nightly data pipeline job using Github Actions to update the data hosted on the site. This is configured in `.github/workflows/data_pipeline.yaml`. Again, each step of the process can be run locally.
+
+### VPN
+
+Unfortunately, the NBA blocks API traffic from many cloud hosting providers, e.g. AWS. In our case, [Github Actions runs on Azure](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#cloud-hosts-for-github-hosted-runners). To get around this issue, I've setup a free ProtonVPN account. The various secrets needed to get that to work (a base certificate, TLS authentication key, and openvpn username & password) are stored as secrets in Github and injected as environment variables in the relevant step. An openvpn config file — `config.ovpn` — can be found in the `vpn` directory, along with a `connect.sh` bash script used by the workflow to set things up.
 
 ### Update Data
 

--- a/app/run.sh
+++ b/app/run.sh
@@ -2,32 +2,34 @@
 set -euf -o pipefail
 
 GIT_SHA=$(git rev-parse --short HEAD)
-DIR="$(cd "$(dirname "${BASH_SOURCE}")" && pwd)"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CMD=(npm run dev)
 
 usage()
 {
-    echo "usage: ./run.sh [--git-sha -g sha=$GIT_SHA] [--command -c cmd]"
+    echo "usage: ./run.sh [--git-sha -g sha=$GIT_SHA] cmd=${CMD[*]}"
 }
 
-while [[ "$#" -gt 0 ]]; do
+while [[ $# -gt 0 ]]; do
     case "$1" in
         -g | --git-sha )
             GIT_SHA="$2"
-            shift 2
-            ;;
-        -c | --command )
-            CMD="$2"
-            echo "Using custom command $CMD"
             shift 2
             ;;
         -h | --help )
             usage
             exit
             ;;
+        -* )
+            echo "Invalid option provided, see below"
+            usage
+            exit 1
+            ;;
         * )
-        echo "Invalid inputs, see below"
-        usage
-        exit 1
+            IFS=" " read -r -a CMD <<< "$@"
+            echo "Using custom command ${CMD[*]}"
+            break
+            ;;
     esac
 done
 
@@ -45,4 +47,4 @@ docker run -it --rm \
     -v /home/app/node_modules \
     -v /home/app/.next \
     matteosox/nba:app-"$GIT_SHA" \
-    $CMD
+    "${CMD[@]}"

--- a/build/app.Dockerfile
+++ b/build/app.Dockerfile
@@ -22,5 +22,3 @@ RUN npm install
 # Build app
 COPY --chown=app app/. .
 RUN npm run build
-
-CMD ["npm", "run", "dev"]

--- a/build/install_packages.sh
+++ b/build/install_packages.sh
@@ -16,7 +16,7 @@ apt-get update
 apt-get -y upgrade
 
 # Install packages, without unnecessary recommended packages:
-apt-get -y install --no-install-recommends $@
+apt-get -y install --no-install-recommends "$@"
 
 # Delete cached files we don't need anymore:
 apt-get clean

--- a/build/notebook.Dockerfile
+++ b/build/notebook.Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04
 
 # Install apt-get packages needed for the base image
 COPY build/install_packages.sh .
-RUN ./install_packages.sh python3-dev python3-pip python3-venv g++ libopenblas-dev git awscli libyaml-dev
+RUN ./install_packages.sh python3-dev python3-pip python3-venv g++ libopenblas-dev git awscli libyaml-dev shellcheck
 
 # Create Jupyter notebook user & switch to it
 RUN useradd --uid 1000 --create-home jupyter

--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -5,24 +5,24 @@ set -ef -o pipefail
 
 GIT_SHA=$(git rev-parse --short HEAD)
 echo "Building for git sha $GIT_SHA"
-DIR="$(cd "$(dirname "${BASH_SOURCE}")" && pwd)"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export DOCKER_BUILDKIT=1
 
 echo "Building notebook Docker image"
 docker build \
     --progress=plain \
-    -t matteosox/nba:notebook-$GIT_SHA \
-    --cache-from matteosox/nba:notebook-$GIT_SHA \
+    -t matteosox/nba:notebook-"$GIT_SHA" \
+    --cache-from matteosox/nba:notebook-"$GIT_SHA" \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
-    --build-arg GIT_SHA=$GIT_SHA \
+    --build-arg GIT_SHA="$GIT_SHA" \
     -f "$DIR"/../build/notebook.Dockerfile \
     "$DIR"/../
 
 echo "Building app Docker image"
 docker build \
     --progress=plain \
-    -t matteosox/nba:app-$GIT_SHA \
-    --cache-from matteosox/nba:app-$GIT_SHA \
+    -t matteosox/nba:app-"$GIT_SHA" \
+    --cache-from matteosox/nba:app-"$GIT_SHA" \
     --build-arg BUILDKIT_INLINE_CACHE=1 \
     -f "$DIR"/../build/app.Dockerfile \
     "$DIR"/../

--- a/cicd/etl.sh
+++ b/cicd/etl.sh
@@ -4,8 +4,8 @@ set -euf -o pipefail
 # Runs etl commands in the notebook container
 
 GIT_SHA=$(git rev-parse --short HEAD)
-DIR="$(cd "$(dirname "${BASH_SOURCE}")" && pwd)"
-LOCAL_ENV_OPTION=""
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_ENV_OPTION=()
 
 usage()
 {
@@ -30,7 +30,7 @@ while true; do
             shift 2
             ;;
         -l | --local-env )
-            LOCAL_ENV_OPTION="--env-file $DIR/../build/notebook.local.env"
+            LOCAL_ENV_OPTION=(--env-file "$DIR"/../build/notebook.local.env)
             echo "Loading local environment parameters"
             shift
             ;;
@@ -44,20 +44,18 @@ while true; do
             exit 2
             ;;
         * )
-            CMD="$@"
+            IFS=" " read -r -a CMD <<< "$@"
             break
             ;;
     esac
 done
 
-
-CMD="$@"
-echo "Running ${CMD} in the notebook container"
+echo "Running ${CMD[*]} in the notebook container"
 
 docker run --rm \
     --name etl \
-    --env-file $DIR/../build/notebook.env \
-    $LOCAL_ENV_OPTION \
-    -v $DIR/../data:/home/jupyter/nba/data \
+    --env-file "$DIR"/../build/notebook.env \
+    "${LOCAL_ENV_OPTION[@]}" \
+    -v "$DIR"/../data:/home/jupyter/nba/data \
     matteosox/nba:notebook-"$GIT_SHA" \
-    $CMD
+    "${CMD[@]}"

--- a/cicd/push.sh
+++ b/cicd/push.sh
@@ -7,7 +7,7 @@ GIT_SHA=$(git rev-parse --short HEAD)
 echo "Pushing images for git sha $GIT_SHA"
 export DOCKER_BUILDKIT=1
 
-docker push matteosox/nba:notebook-$GIT_SHA
-docker push matteosox/nba:app-$GIT_SHA
+docker push matteosox/nba:notebook-"$GIT_SHA"
+docker push matteosox/nba:app-"$GIT_SHA"
 
 echo "All done!"

--- a/cicd/test.sh
+++ b/cicd/test.sh
@@ -3,45 +3,81 @@ set -euf -o pipefail
 
 GIT_SHA=$(git rev-parse --short HEAD)
 echo "Running tests for git sha $GIT_SHA"
-DIR="$(cd "$(dirname "${BASH_SOURCE}")" && pwd)"
+DIR="$(cd "$(dirname "${BASH_SOURCE[@]}")" && pwd)"
+
+BLACK_STATUS="NOT STARTED"
+PYLINT_STATUS="NOT STARTED"
+PYTHON_UNIT_TESTS_STATUS="NOT STARTED"
+SHELLCHECK_STATUS="NOT STARTED"
 EXIT_CODE=0
 
-echo "Running Black Python linting"
-BLACK_STATUS=FAIL
-docker run \
+report_status() {
+    echo "Test Summary"
+    echo "  - Black Python Linting: $BLACK_STATUS"
+    echo "  - Pylint: $PYLINT_STATUS"
+    echo "  - Python Unit Tests: $PYTHON_UNIT_TESTS_STATUS"
+    echo "  - ShellCheck: $SHELLCHECK_STATUS"
+}
+trap report_status EXIT
+
+echo "Running Black"
+BLACK_STATUS=RUNNING
+if docker run \
     --rm \
     --name black_linting \
     -v "$DIR"/../:/home/jupyter/nba \
-    matteosox/nba:notebook-$GIT_SHA \
-    black --verbose --check nba \
-    && BLACK_STATUS=SUCCESS \
-    || EXIT_CODE=1
+    matteosox/nba:notebook-"$GIT_SHA" \
+    black --verbose --check nba
+then
+    BLACK_STATUS=SUCCESS
+else
+    EXIT_CODE=1
+    BLACK_STATUS=FAILED
+fi
 
-echo "Running pylint"
-PYLINT_STATUS=FAIL
-docker run \
+echo "Running Pylint"
+PYLINT_STATUS=RUNNING
+if docker run \
     --rm \
     --name pylint \
     -v "$DIR"/../:/home/jupyter/nba \
-    matteosox/nba:notebook-$GIT_SHA \
-    pylint --rcfile nba/pylintrc nba \
-    && PYLINT_STATUS=SUCCESS \
-    || EXIT_CODE=1
+    matteosox/nba:notebook-"$GIT_SHA" \
+    pylint --rcfile nba/pylintrc nba
+then
+    PYLINT_STATUS=SUCCESS
+else
+    EXIT_CODE=1
+    PYLINT_STATUS=FAILED
+fi
 
 echo "Running Python unit tests"
-PYTHON_UNIT_TESTS_STATUS=FAIL
-docker run \
+PYTHON_UNIT_TESTS_STATUS=RUNNING
+if docker run \
     --rm \
     --name python_unit_test \
     -v "$DIR"/../:/home/jupyter/nba \
-    matteosox/nba:notebook-$GIT_SHA \
-    python -m unittest discover --verbose --start-directory nba \
-    && PYTHON_UNIT_TESTS_STATUS=SUCCESS \
-    || EXIT_CODE=1
+    matteosox/nba:notebook-"$GIT_SHA" \
+    python -m unittest discover --verbose --start-directory nba
+then
+    PYTHON_UNIT_TESTS_STATUS=SUCCESS
+else
+    EXIT_CODE=1
+    PYTHON_UNIT_TESTS_STATUS=FAILED
+fi
 
-echo "Test Summary"
-echo "  - Black Python Linting: $BLACK_STATUS"
-echo "  - Pylint: $PYLINT_STATUS"
-echo "  - Python Unit Tests: $PYTHON_UNIT_TESTS_STATUS"
+echo "Running ShellCheck"
+SHELLCHECK_STATUS=RUNNING
+if docker run \
+    --rm \
+    --name shellcheck \
+    -v "$DIR"/../:/home/jupyter/nba \
+    matteosox/nba:notebook-"$GIT_SHA" \
+    ./nba/test/shellcheck.sh
+then
+    SHELLCHECK_STATUS=SUCCESS
+else
+    EXIT_CODE=1
+    SHELLCHECK_STATUS=FAILED
+fi
 
 exit $EXIT_CODE

--- a/developer_setup.sh
+++ b/developer_setup.sh
@@ -1,27 +1,27 @@
 #! /usr/bin/env bash
 set -euf -o pipefail
 
-DIR="$(cd "$(dirname "${BASH_SOURCE}")" && pwd)"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "Setting up git pre-commit hook"
-ln -s $DIR/test/pre-commit $DIR/.git/hooks/pre-commit
+ln -s "$DIR"/test/pre-commit "$DIR"/.git/hooks/pre-commit
 
 echo "Before going further, you'll need a build/notebook.local.env file."
 echo "We'll create an empty one for you now, but in the future, you'll need to add your local config options (usually secrets) to it"
-touch $DIR/build/notebook.local.env
+touch "$DIR"/build/notebook.local.env
 
 echo "With that out of the way, let's build and test the repo"
-$DIR/cicd/build.sh
-$DIR/cicd/test.sh
+"$DIR"/cicd/build.sh
+"$DIR"/cicd/test.sh
 
 echo "All done building and running tests, now time to try updating the requirements."
 echo "NOTE: This will edit the repo, but no need to keep those edits."
-$DIR/requirements/update_requirements_inside_docker.sh
+"$DIR"/requirements/update_requirements_inside_docker.sh
 
 echo "Next up, we'll run the app locally."
 echo "Once you're happy with the result, hit ctrl-c to continue to the next step."
-$DIR/app/run.sh
+"$DIR"/app/run.sh
 
 echo "Moving on to the final step: running the Jupyter notebook environment."
 echo "Again, once you're happy with the result, hit ctrl-c."
-$DIR/notebooks/run.sh
+"$DIR"/notebooks/run.sh

--- a/notebooks/run.sh
+++ b/notebooks/run.sh
@@ -4,7 +4,7 @@ set -euf -o pipefail
 # Opens up a Jupyter notebook in a Docker container
 
 GIT_SHA=$(git rev-parse --short HEAD)
-DIR="$(cd "$(dirname "${BASH_SOURCE}")" && pwd)"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PORT=8888
 IP=0.0.0.0
 
@@ -47,20 +47,20 @@ echo "Opening up a Jupyter notebook in your browser at http://$IP:$PORT for git 
 
 open_browser() {
     sleep 2
-    python -m webbrowser http://$IP:$PORT
+    python -m webbrowser http://"$IP":"$PORT"
 }
 
 open_browser &
 docker run --rm \
-    -p $PORT:$PORT \
+    -p "$PORT":"$PORT" \
     --name notebook \
-    --env-file $DIR/../build/notebook.env \
-    --env-file $DIR/../build/notebook.local.env \
-    -v $DIR/../:/home/jupyter/nba \
-    matteosox/nba:notebook-$GIT_SHA \
+    --env-file "$DIR"/../build/notebook.env \
+    --env-file "$DIR"/../build/notebook.local.env \
+    -v "$DIR"/../:/home/jupyter/nba \
+    matteosox/nba:notebook-"$GIT_SHA" \
     jupyter notebook \
-    --ip=$IP \
+    --ip="$IP" \
     --no-browser \
     --NotebookApp.token='' \
     --NotebookApp.notebook_dir=/home/jupyter/nba/notebooks \
-    --port=$PORT
+    --port="$PORT"

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,6 +1,5 @@
 PyYaml
 pip-tools
-changelog-cli
 black
 pylint
 jupyter

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -71,16 +71,16 @@ bleach==3.3.0 \
 bokeh==2.3.1 \
     --hash=sha256:2f2fb8bab8ca8fa039f48b1f0bed56d3a847c75694ece1d206ffab645ff5beec
     # via -r /home/jupyter/nba/requirements/requirements.in
-boto3==1.17.53 \
-    --hash=sha256:1d26f6e7ae3c940cb07119077ac42485dcf99164350da0ab50d0f5ad345800cd \
-    --hash=sha256:3bf3305571f3c8b738a53e9e7dcff59137dffe94670046c084a17f9fa4599ff3
+boto3==1.17.56 \
+    --hash=sha256:9caec835fdf9c3336068a28004bb6a6ffab14a75d2466dfe6e279946f409fe8f \
+    --hash=sha256:ccbc640b6c7b27626f87fbd6d73872ec697290065e8f473b6a3def472dd9253f
     # via
     #   -r /home/jupyter/nba/requirements/requirements.in
     #   awswrangler
     #   redshift-connector
-botocore==1.20.53 \
-    --hash=sha256:d5e70d17b91c9b5867be7d6de0caa7dde9ed789bed62f03ea9b60718dc9350bf \
-    --hash=sha256:e303500c4e80f6a706602da53daa6f751cfa8f491665c99a24ee732ab6321573
+botocore==1.20.56 \
+    --hash=sha256:134a7b1d21030b6323b6094226d0cc898a8f2a2b5d27e1e5c0a0071372eab68d \
+    --hash=sha256:367a7eaee80fdf7718f50461432ac2c4bd73363835a1ad011f99fdc592ba775d
     # via
     #   awswrangler
     #   boto3
@@ -171,10 +171,6 @@ cftime==1.4.1 \
     --hash=sha256:e2919d68bebed66f102f861d7f2fb396487d44f5f54b1ac19f1e74be3f67b02c \
     --hash=sha256:fee0af10a85c03b4d3512eed04ffb2f80a0f2e8fe712df30bde2f1fe8fe37cf7
     # via netcdf4
-changelog-cli==0.7.1 \
-    --hash=sha256:332090b98c958e06486632a7967cdd6edf3896ade4171a21f83b768eac519170 \
-    --hash=sha256:aaae0cfeb3681a4d7b10993f945dedf19c761b7582625f75a7abdd7272808f73
-    # via -r /home/jupyter/nba/requirements/requirements.in
 chardet==4.0.0 \
     --hash=sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa \
     --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5
@@ -184,7 +180,6 @@ click==7.1.2 \
     --hash=sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc
     # via
     #   black
-    #   changelog-cli
     #   pip-tools
 cycler==0.10.0 \
     --hash=sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d \
@@ -889,8 +884,8 @@ qtpy==1.9.0 \
     --hash=sha256:2db72c44b55d0fe1407be8fba35c838ad0d6d3bb81f23007886dc1fc0f459c8d \
     --hash=sha256:fa0b8363b363e89b2a6f49eddc162a04c0699ae95e109a6be3bb145a913190ea
     # via qtconsole
-redshift-connector==2.0.877 \
-    --hash=sha256:b4e587715ae62d9bab53ea89fb3348811d2dacee4ec59a9d8a2be5b108a84542
+redshift-connector==2.0.878 \
+    --hash=sha256:52725509a38e3115841b27c32255a3f1beb134dfdf6c408c6b6fd963f66d41f5
     # via awswrangler
 regex==2021.4.4 \
     --hash=sha256:01afaf2ec48e196ba91b37451aa353cb7eda77efe518e481707e0515025f0cd5 \
@@ -942,9 +937,9 @@ requests==2.25.1 \
     #   -r /home/jupyter/nba/requirements/requirements.in
     #   pbpstats
     #   redshift-connector
-s3transfer==0.3.7 \
-    --hash=sha256:35627b86af8ff97e7ac27975fe0a98a312814b46c6333d8a6b889627bcd80994 \
-    --hash=sha256:efa5bd92a897b6a8d5c1383828dca3d52d0790e0756d49740563a3fb6ed03246
+s3transfer==0.4.2 \
+    --hash=sha256:9b3752887a2880690ce628bc263d6d13a3864083aeacff4890c1c9839a5eb0bc \
+    --hash=sha256:cb022f4b16551edebbb31a377d3f09600dbada7363d8c5db7976e7f47732e1b2
     # via boto3
 scipy==1.6.2 \
     --hash=sha256:03f1fd3574d544456325dae502facdf5c9f81cbfe12808a5e67a737613b7ba8c \

--- a/requirements/update_requirements.sh
+++ b/requirements/update_requirements.sh
@@ -3,6 +3,6 @@ set -euf -o pipefail
 
 # Updates the requirements.txt file
 
-DIR="$(cd "$(dirname "${BASH_SOURCE}")" && pwd)"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 pip-compile --generate-hashes --allow-unsafe -v "$DIR"/requirements.in > "$DIR"/requirements.txt

--- a/requirements/update_requirements_inside_docker.sh
+++ b/requirements/update_requirements_inside_docker.sh
@@ -5,12 +5,12 @@ set -euf -o pipefail
 
 GIT_SHA=$(git rev-parse --short HEAD)
 echo "Updating requirements for git sha $GIT_SHA"
-DIR="$(cd "$(dirname "${BASH_SOURCE}")" && pwd)"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 docker run \
     --rm \
     -v "$DIR"/../:/home/jupyter/nba \
     -e "LC_ALL=C.UTF-8" \
     -e "LANG=C.UTF-8" \
-    matteosox/nba:notebook-$GIT_SHA \
+    matteosox/nba:notebook-"$GIT_SHA" \
     ./nba/requirements/update_requirements.sh

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,6 @@
 """Install pynba Python package"""
 
-import os
-
 from setuptools import setup, find_packages
-
-
-def dir_path():
-    """Get directory of this file"""
-    return os.path.dirname(os.path.realpath(__file__))
 
 
 setup(
@@ -27,6 +20,7 @@ setup(
             "settings.toml",
         ],
     },
+    python_requires=">=3.8",
     install_requires=[
         "pbpstats",
         "pandas",

--- a/test/black_lint.sh
+++ b/test/black_lint.sh
@@ -3,12 +3,12 @@ set -euf -o pipefail
 
 GIT_SHA=$(git rev-parse --short HEAD)
 echo "Black formatting for git sha $GIT_SHA"
-DIR="$(cd "$(dirname "${BASH_SOURCE}")" && pwd)"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "Running Black Python linting"
 docker run \
     --rm \
     --name black_linting \
     -v "$DIR"/../:/home/jupyter/nba \
-    matteosox/nba:notebook-$GIT_SHA \
+    matteosox/nba:notebook-"$GIT_SHA" \
     black --verbose nba

--- a/test/pre-commit
+++ b/test/pre-commit
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 set -euf -o pipefail
 
-DIR="$(cd "$(dirname "${BASH_SOURCE}")" && pwd)"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "Buildin'..."
 $DIR/../../cicd/build.sh

--- a/test/shellcheck.sh
+++ b/test/shellcheck.sh
@@ -1,0 +1,30 @@
+#! /usr/bin/env bash
+set -euf -o pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$DIR"/..
+
+EXIT_CODE=0
+BASH_SCRIPTS=$(git ls-files | grep ".*\.sh$")
+declare -A STATUSES
+
+report_status() {
+    echo "Shellcheck Summary"
+    for script in $BASH_SCRIPTS; do
+        status=${STATUSES[$script]:-"NOT STARTED"}
+        echo "  - $script: $status"
+    done
+}
+trap report_status EXIT
+
+for script in $BASH_SCRIPTS; do
+    STATUSES[$script]=RUNNING
+    if shellcheck "$script"; then
+        STATUSES[$script]=SUCCESS
+    else
+        EXIT_CODE=1
+        STATUSES[$script]=FAILED
+    fi
+done
+
+exit $EXIT_CODE


### PR DESCRIPTION
- Added `workflow_dispatch` option to github actions workflows so they can be triggered manually.
- Added badges to the `README.md`.
- Documented the VPN
- Now using `shellcheck` to test bash scripts, in `./test/shellcheck.sh`.
- This was added to the `./cicd/test.sh` CI test suite.
- This lead to a lot of quoting of bash variables and other small changes to every bash script in the repo.
- Notably, `./app/run.sh` now has an optional positional command argument, which is nicely handled to pass to Docker.
- Similar improvement to the `./cicd/etl.sh` scripts command input.
- `./cicd/test.sh` improvements to show test results summary.
- Removed `changelog-cli` from `requirements.in` since we don't use it anymore.
- Removed a bit of unnecessary code in `setup.py` left around from removing the `VERSION`.
- Now requiring Python >= 3.8 when installing `pynba`.
- `./vpn/connect.sh` now deletes secrets written to files upon completion.
- Bugfix for Data Pipeline workflow, no longer using `sudo` when calling `./vpn/connect.sh`, which was removing all of our exported env variables.