### PR TITLE
CI Fixes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,0 @@
-.github
-notebooks
-data
-app/.config
-app/.next
-app/.npm
-app/node_modules
-app/run.sh

--- a/.github/workflows/setup_test_push.yaml
+++ b/.github/workflows/setup_test_push.yaml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Setup, Test, & Push
 
 on:
   push:
@@ -10,12 +10,15 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_and_test:
+  setup_test_push:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Setup File Permissions
+        run: build/set_file_permissions.sh
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1
@@ -23,8 +26,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build
-        run: cicd/build.sh
+      - name: Setup
+        run: cicd/setup.sh
 
       - name: Test
         run: cicd/test.sh

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h3 align="center">
 Status<br>
 <a href="https://github.com/matteosox/nba/actions/workflows/data_pipeline.yaml"><img alt="Data Pipeline" src="https://github.com/matteosox/nba/actions/workflows/data_pipeline.yaml/badge.svg"></a>
-<a href="https://github.com/matteosox/nba/actions/workflows/build_test.yaml"><img alt="Build and Test" src="https://github.com/matteosox/nba/actions/workflows/build_test.yaml/badge.svg"></a>
+<a href="https://github.com/matteosox/nba/actions/workflows/setup_test_push.yaml"><img alt="Setup, Test, & Build" src="https://github.com/matteosox/nba/actions/workflows/setup_test_push.yaml/badge.svg"></a>
 <a href="https://nba.mattefay.com"><img alt="Website Status" src="https://img.shields.io/website?down_color=red&down_message=offline&label=nba.mattefay.com&up_color=brightgreen&up_message=online&url=https%3A%2F%2Fnba.mattefay.com"></a>
 <br>Languages<br>
 <a href="https://docs.python.org/3.8/"><img alt="Python: 3.8" src="https://img.shields.io/static/v1?label=Python&message=3%2C8&logo=python&color=%233776AB"></a>
@@ -81,14 +81,14 @@ We use a Dockerized Jupyter notebook environment for data analysis. The `noteboo
 
 _TL;DR: Run `./developer_setup.sh`._
 
-We use Docker for a clean environment within which to build, test, analyze, and so on. The `build.sh` script in the `cicd` directory will build the relevant images for you. Running things natively isn't a supported/maintained thing.
+We use Docker for a clean environment within which to build, test, analyze, and so on. The `setup.sh` script in the `cicd` directory will build the relevant images for you. Running things natively isn't a supported/maintained thing.
 
 To get you setup, you can run `./developer_setup.sh`. This will:
 1) Symlink `test/pre-commit` to your `.git` directory, so that you'll automatically build and test code before you commit it.
 2) Create an empty `build/notebook.local.env` file in which you can place local secrets for the notebook docker container.
 3) Git only tracks a single executable bit for all files, so when setting up the repo, we need to set file permissions manually for files we need to write to from Docker. The `set_file_permissions.sh` script does this for you.
 
-With all that out of the way, it then puts your machine through its paces by building, testing, and running various other workflows locally.
+With all that out of the way, it then puts your machine through its paces by setting up, testing, and running various other workflows locally.
 
 ### Code Style
 
@@ -96,7 +96,7 @@ We use PEP8 for Python, but don't trip, just run `test/black_lint.sh` to get all
 
 ### Committing Code
 
-We use the `pre-commit` git hook to run the buildin' and testin' phases of our CI/CD pipeline locally.
+We use the `pre-commit` git hook to run the settin' up and testin' phases of our CI/CD pipeline locally.
 
 ### Pull Requests
 
@@ -136,15 +136,15 @@ _TL;DR: Run `app/run.sh`._
 
 To ease developing the NextJS web app, we use `npm run dev` in a Docker container with the app mounted. This starts the app in [development mode](https://nextjs.org/docs/api-reference/cli#development), which takes advantage of NextJS's [fast refresh](https://nextjs.org/docs/basic-features/fast-refresh) functionality, which catches exceptions and loads code updates near-instantaneously.
 
-Additionally, if you'd like to run a different command, e.g. to update the npm packages installed using `npm install`, you can use the same script with an optional command, e.g. `app/run.sh YOUR CMD HERE`.
+Additionally, if you'd like to run a different command, e.g. to install a new npm package using `npm install new-package`, you can use the same script with an optional command, e.g. `app/run.sh YOUR CMD HERE`.
 
 ## Continuous Integration
 
-We use Github actions to run our CI pipeline on every pull request. The configuration can be found in `.github/workflows/build_test.yaml`. That said, every step of CI can also be run locally.
+We use Github actions to run our CI pipeline on every pull request. The configuration can be found in `.github/workflows/setup_test_push.yaml`. That said, every step of CI can also be run locally.
 
-### Buildin'
+### Settin' up
 
-_TL;DR: To run tests, run `cicd/build.sh`._
+_TL;DR: To run tests, run `cicd/setup.sh`._
 
 This builds the two relevant docker images, `notebook`, and `app`.
 
@@ -191,6 +191,10 @@ In Docker Hub, we have one repository per image:
     - `app` -> `matteosox/nba-app`
 
 In addition to pushing each image with a tag as the git SHA of the code producing it, we also push an untagged (i.e. tagged as `latest`) image when pushing from the `main` branch.
+
+### Buildin'
+
+We don't build the Next.js app in the `setup_test_push.yaml` Github Actions workflow because Vercel is configured to do this for us. That said, as with all other CI workflows, we support running these locally. To build the app, use `app/build.sh`.
 
 ## Data Pipeline
 

--- a/app.Dockerfile.dockerignore
+++ b/app.Dockerfile.dockerignore
@@ -1,0 +1,9 @@
+# Exclude everything
+*
+
+# Except files we explicitly need
+!build/install_packages.sh
+!build/install_node.sh
+!app/package.json
+!app/package-lock.json
+!build/entrypoint.sh

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -28,7 +28,3 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
-
-# other stuff
-.config
-.npm

--- a/app/build.sh
+++ b/app/build.sh
@@ -1,0 +1,14 @@
+#! /usr/bin/env bash
+set -ef -o pipefail
+
+# Build the Next.js web app
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$DIR"/..
+
+GIT_SHA=$(git rev-parse --short HEAD)
+echo "Building the Next.js app for git sha $GIT_SHA"
+
+app/run.sh --no-browser npm --prefix app run build
+
+echo "All done!"

--- a/app/run.sh
+++ b/app/run.sh
@@ -6,11 +6,12 @@ REPO_DIR="$DIR"/..
 cd "$REPO_DIR"
 
 GIT_SHA=$(git rev-parse --short HEAD)
-CMD=(npm run dev)
+CMD=(npm --prefix app run dev)
+BROWSER=true
 
 usage()
 {
-    echo "usage: run.sh [--git-sha -g sha=$GIT_SHA] cmd=${CMD[*]}"
+    echo "usage: run.sh [--git-sha -g sha=$GIT_SHA] [--no-browser -n] cmd=${CMD[*]}"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -18,6 +19,10 @@ while [[ $# -gt 0 ]]; do
         -g | --git-sha )
             GIT_SHA="$2"
             shift 2
+            ;;
+        -n | --no-browser )
+            BROWSER=false
+            shift
             ;;
         -h | --help )
             usage
@@ -43,11 +48,13 @@ open_browser() {
     python -m webbrowser http://localhost:3000
 }
 
-open_browser &
+if "$BROWSER"; then
+    open_browser &
+fi
+
 docker run -it --rm \
     -p 3000:3000 \
-    -v "$REPO_DIR"/app:/home/app \
-    -v /home/app/node_modules \
-    -v /home/app/.next \
+    -v "$REPO_DIR"/app:/home/app/app \
+    -v /home/app/app/node_modules \
     matteosox/nba-app:"$GIT_SHA" \
     "${CMD[@]}"

--- a/build/install_fonts.sh
+++ b/build/install_fonts.sh
@@ -1,0 +1,9 @@
+#! /usr/bin/env bash
+set -euf -o pipefail
+
+# Installs the ttf-mscorefonts-installer package, which requires some fanciness to agree to the
+# end user license agreement automatically. Inspired by:
+# https://askubuntu.com/questions/16225/how-can-i-accept-the-microsoft-eula-agreement-for-ttf-mscorefonts-installer/25614#25614
+
+echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections
+install_packages.sh ttf-mscorefonts-installer

--- a/build/notebook.Dockerfile
+++ b/build/notebook.Dockerfile
@@ -1,9 +1,11 @@
 # syntax=docker/dockerfile:1.2
 FROM ubuntu:20.04
 
-# Install apt-get packages needed for the base image
+# Install apt-get packages
 COPY build/install_packages.sh /usr/local/bin/install_packages.sh
 RUN install_packages.sh python3-dev python3-pip python3-venv g++ libopenblas-dev git awscli libyaml-dev shellcheck gosu
+COPY build/install_fonts.sh /usr/local/bin/install_fonts.sh
+RUN install_fonts.sh
 
 # Create Jupyter notebook user & switch to it
 ENV USER=jupyter
@@ -19,7 +21,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 # Install python dependencies
 COPY --chown="$USER" requirements/requirements.txt .
 RUN mkdir -p .cache/pip
-RUN --mount=type=cache,target=/home/"$USER"/.cache/pip,uid=1024 pip install --upgrade pip wheel setuptools && pip install -r requirements.txt
+RUN --mount=type=cache,target=/home/jupyter/.cache/pip,uid=1024 pip install --upgrade pip wheel setuptools && pip install -r requirements.txt
 
 # Copy over source code and packaging files
 COPY --chown="$USER" pynba nba/pynba
@@ -29,7 +31,7 @@ COPY --chown="$USER" setup.py nba/setup.py
 RUN pip install --editable nba/.
 
 # Setup entrypoint for optional custom user id configuration
-COPY --chown="$USER" build/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY build/entrypoint.sh /usr/local/bin/entrypoint.sh
 USER root
 ENTRYPOINT [ "entrypoint.sh" ]
 CMD ["bash"]

--- a/cicd/setup.sh
+++ b/cicd/setup.sh
@@ -1,13 +1,13 @@
 #! /usr/bin/env bash
 set -ef -o pipefail
 
-# Build step for CICD
+# Setup step for CI
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$DIR"/..
 
 GIT_SHA=$(git rev-parse --short HEAD)
-echo "Building for git sha $GIT_SHA"
+echo "Setting up for git sha $GIT_SHA"
 export DOCKER_BUILDKIT=1
 
 echo "Building notebook Docker image"

--- a/developer_setup.sh
+++ b/developer_setup.sh
@@ -14,11 +14,15 @@ touch build/notebook.local.env
 echo "Since git only stores a single executable bit for file permissions, we'll need to configure file permissions as well."
 build/set_file_permissions.sh
 
-echo "With that out of the way, let's build and test the repo"
-cicd/build.sh
+echo "With that out of the way, let's setup and test the repo"
+cicd/setup.sh
 cicd/test.sh
 
-echo "All done building and running tests, now time to try updating the requirements."
+echo "That seems to have worked. Vercel builds the Next.js app for us in CI, but we can also do that locally."
+echo "Let's test that out."
+app/build.sh
+
+echo "All done setting up and running tests, now time to try updating the requirements."
 echo "NOTE: This will edit the repo, but no need to keep those edits."
 requirements/update_requirements_inside_docker.sh
 

--- a/notebook.Dockerfile.dockerignore
+++ b/notebook.Dockerfile.dockerignore
@@ -1,0 +1,10 @@
+# Exclude everything
+*
+
+# Except files we explicitly need
+!build/install_packages.sh
+!build/install_fonts.sh
+!requirements/requirements.txt
+!pynba
+!setup.py
+!build/entrypoint.sh

--- a/notebooks/run.sh
+++ b/notebooks/run.sh
@@ -59,7 +59,9 @@ docker run --rm \
     --name notebook \
     --env-file build/notebook.env \
     --env-file build/notebook.local.env \
-    -v "$REPO_DIR":/home/jupyter/nba \
+    -v "$REPO_DIR"/pynba:/home/jupyter/nba/pynba \
+    -v "$REPO_DIR"/data:/home/jupyter/nba/data \
+    -v "$REPO_DIR"/notebooks:/home/jupyter/nba/notebooks \
     matteosox/nba-notebook:"$GIT_SHA" \
     jupyter notebook \
     --ip="$IP" \

--- a/test/pre-commit
+++ b/test/pre-commit
@@ -5,7 +5,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$DIR"/../..
 cd "$REPO_DIR"
 
-echo "Buildin'..."
-cicd/build.sh
+echo "Settin' up..."
+cicd/setup.sh
 echo "Testin'..."
 cicd/test.sh


### PR DESCRIPTION
- Now using two different `.dockerignore` files, one for each image.
- `.dockerignore` files are now much more restrictive.
- Renamed `cicd/build.sh` to `cicd/setup.sh` to reflect it's setting up the environment, not building the web app.
- Wrote a `app/build.sh` script to build the Next.js app.
- Added the `--no-browser` option to `app/run.sh`.
- `app` docker image now installs the app in `~/app` instead of directly in `~`.
- Figured out how to cache npm with the inline docker run mounted volume.
- Installed some fonts in the `notebook` docker image.
- Fixed the docker run mounted cache for pip. Apparently the path can't contain env variables.
- `notebooks/run.sh` now mounts specific directories instead of the whole repo.